### PR TITLE
Fix job spam when pawn is in mental state

### DIFF
--- a/Source/PickUpAndHaul/PawnUnloadChecker.cs
+++ b/Source/PickUpAndHaul/PawnUnloadChecker.cs
@@ -1,13 +1,19 @@
 ﻿namespace PickUpAndHaul;
 public class PawnUnloadChecker
 {
-	public static void CheckIfPawnShouldUnloadInventory(Pawn pawn, bool forced = false)
-	{
-		// Check if save operation is in progress
-		if (PickupAndHaulSaveLoadLogger.IsSaveInProgress())
-		{
-			return; // Skip unload checking during save operations
-		}
+        public static void CheckIfPawnShouldUnloadInventory(Pawn pawn, bool forced = false)
+        {
+                // Check if save operation is in progress
+                if (PickupAndHaulSaveLoadLogger.IsSaveInProgress())
+                {
+                        return; // Skip unload checking during save operations
+                }
+
+                // Ignore pawns that are currently in a mental state
+                if (pawn == null || pawn.InMentalState)
+                {
+                        return;
+                }
 
 		var job = JobMaker.MakeJob(PickUpAndHaulJobDefOf.UnloadYourHauledInventory, pawn);
 		var itemsTakenToInventory = pawn?.GetComp<CompHauledToInventory>();


### PR DESCRIPTION
## Summary
- skip unload checks if pawn is in a mental state
- never create hauling jobs for pawns in a mental state

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7d8b2bc8833280ed3b171ecbd076