### PR TITLE
Fix haul job zero count issue

### DIFF
--- a/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
@@ -496,43 +496,38 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 		var storeCell = allocation.Key;
 
 		//Can't stack with allocated cells, find a new cell:
-		if (storeCell == default)
-		{
+                if (storeCell == default)
+                {
                         if (TryFindBestBetterStorageFor(nextThing, pawn, map, currentPriority, pawn.Faction, out var nextStoreCell, out var haulDestination, out var innerInteractableThingOwner))
-			{
-				if (innerInteractableThingOwner is null)
-				{
-					storeCell = new(nextStoreCell);
-					job.targetQueueB.Add(nextStoreCell);
+                        {
+                                if (innerInteractableThingOwner is null)
+                                {
+                                        storeCell = new(nextStoreCell);
+                                        job.targetQueueB.Add(nextStoreCell);
 
-					storeCellCapacity[storeCell] = new(nextThing, CapacityAt(nextThing, nextStoreCell, map));
+                                        storeCellCapacity[storeCell] = new(nextThing, CapacityAt(nextThing, nextStoreCell, map));
 
-					Log.Message($"New cell for unstackable {nextThing} = {nextStoreCell}");
-				}
-				else
-				{
-					var destinationAsThing = (Thing)haulDestination;
-					storeCell = new(destinationAsThing);
-					job.targetQueueB.Add(destinationAsThing);
+                                        Log.Message($"New cell for unstackable {nextThing} = {nextStoreCell}");
+                                }
+                                else
+                                {
+                                        var destinationAsThing = (Thing)haulDestination;
+                                        storeCell = new(destinationAsThing);
+                                        job.targetQueueB.Add(destinationAsThing);
 
-					storeCellCapacity[storeCell] = new(nextThing, innerInteractableThingOwner.GetCountCanAccept(nextThing));
+                                        storeCellCapacity[storeCell] = new(nextThing, innerInteractableThingOwner.GetCountCanAccept(nextThing));
 
-					Log.Message($"New haulDestination for unstackable {nextThing} = {haulDestination}");
-				}
-			}
-			else
-			{
-				Log.Message($"{nextThing} can't stack with allocated cells");
+                                        Log.Message($"New haulDestination for unstackable {nextThing} = {haulDestination}");
+                                }
+                        }
+                        else
+                        {
+                                Log.Message($"{nextThing} can't stack with allocated cells");
 
-				if (job.targetQueueA.NullOrEmpty())
-				{
-					job.targetQueueA.Add(nextThing);
-				}
-
-				PerformanceProfiler.EndTimer("AllocateThingAtCell");
-				return false;
-			}
-		}
+                                PerformanceProfiler.EndTimer("AllocateThingAtCell");
+                                return false;
+                        }
+                }
 
 		job.targetQueueA.Add(nextThing);
 		var count = nextThing.stackCount;
@@ -576,19 +571,28 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 					Log.Message($"New haulDestination {nextHaulDestination}:{capacity}, allocated extra {capacityOver}");
 				}
 			}
-			else
-			{
-				count -= capacityOver;
-				job.countQueue.Add(count);
-				Log.Message($"Nowhere else to store, allocated {nextThing}:{count}");
-				PerformanceProfiler.EndTimer("AllocateThingAtCell");
-				return false;
-			}
-		}
-		job.countQueue.Add(count);
-		Log.Message($"{nextThing}:{count} allocated");
-		PerformanceProfiler.EndTimer("AllocateThingAtCell");
-		return true;
+                        else
+                        {
+                                count -= capacityOver;
+                                if (count <= 0)
+                                {
+                                        job.targetQueueA.RemoveAt(job.targetQueueA.Count - 1);
+                                        PerformanceProfiler.EndTimer("AllocateThingAtCell");
+                                        return false;
+                                }
+                                job.countQueue.Add(count);
+                                Log.Message($"Nowhere else to store, allocated {nextThing}:{count}");
+                                PerformanceProfiler.EndTimer("AllocateThingAtCell");
+                                return false;
+                        }
+                }
+                if (count > 0)
+                {
+                        job.countQueue.Add(count);
+                        Log.Message($"{nextThing}:{count} allocated");
+                }
+                PerformanceProfiler.EndTimer("AllocateThingAtCell");
+                return true;
 	}
 
 	//public static HashSet<StoreTarget> skipTargets;


### PR DESCRIPTION
## Summary
- avoid queuing haul targets when no storage cell is available
- drop zero-count allocations when capacity is exhausted

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6871d199ba0c8332aeba3cbc4eb86b7d