### PR TITLE
Fix target queue cleanup logic

### DIFF
--- a/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
@@ -494,7 +494,7 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
                         ?? storeTarget.cell.GetSlotGroup(map).parent.Accepts(nextThing))
                         && Stackable(nextThing, kvp));
                 var storeCell = allocation.Key;
-                var addedTargetB = false;
+                var targetsAddedCount = 0;
 
                 //Can't stack with allocated cells, find a new cell:
                 if (storeCell == default)
@@ -505,7 +505,7 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
                                 {
                                         storeCell = new(nextStoreCell);
                                         job.targetQueueB.Add(nextStoreCell);
-                                        addedTargetB = true;
+                                        targetsAddedCount++;
 
                                         storeCellCapacity[storeCell] = new(nextThing, CapacityAt(nextThing, nextStoreCell, map));
 
@@ -516,7 +516,7 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
                                         var destinationAsThing = (Thing)haulDestination;
                                         storeCell = new(destinationAsThing);
                                         job.targetQueueB.Add(destinationAsThing);
-                                        addedTargetB = true;
+                                        targetsAddedCount++;
 
                                         storeCellCapacity[storeCell] = new(nextThing, innerInteractableThingOwner.GetCountCanAccept(nextThing));
 
@@ -554,6 +554,7 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 				{
 					storeCell = new(nextStoreCell);
 					job.targetQueueB.Add(nextStoreCell);
+					targetsAddedCount++;
 
 					var capacity = CapacityAt(nextThing, nextStoreCell, map) - capacityOver;
 					storeCellCapacity[storeCell] = new(nextThing, capacity);
@@ -565,6 +566,7 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 					var destinationAsThing = (Thing)nextHaulDestination;
 					storeCell = new(destinationAsThing);
 					job.targetQueueB.Add(destinationAsThing);
+					targetsAddedCount++;
 
 					var capacity = innerInteractableThingOwner.GetCountCanAccept(nextThing) - capacityOver;
 
@@ -578,8 +580,11 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
                                 count -= capacityOver;
                                 if (count <= 0)
                                 {
-                                        if (addedTargetB && job.targetQueueB.Count > 0)
+                                        // Clean up all targets added during this allocation
+                                        for (int i = 0; i < targetsAddedCount && job.targetQueueB.Count > 0; i++)
+                                        {
                                                 job.targetQueueB.RemoveAt(job.targetQueueB.Count - 1);
+                                        }
                                         PerformanceProfiler.EndTimer("AllocateThingAtCell");
                                         Log.Message($"Nowhere else to store, skipping {nextThing} due to zero capacity");
                                         return false;
@@ -593,8 +598,11 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 
                 if (count <= 0)
                 {
-                        if (addedTargetB && job.targetQueueB.Count > 0)
+                        // Clean up all targets added during this allocation
+                        for (int i = 0; i < targetsAddedCount && job.targetQueueB.Count > 0; i++)
+                        {
                                 job.targetQueueB.RemoveAt(job.targetQueueB.Count - 1);
+                        }
                         PerformanceProfiler.EndTimer("AllocateThingAtCell");
                         Log.Message($"Skipping {nextThing} due to zero capacity");
                         return false;


### PR DESCRIPTION
Replace boolean `addedTargetB` with integer `targetsAddedCount` to accurately track and clean up `job.targetQueueB` entries, preventing orphaned storage reservations.