### PR TITLE
Optimize hauling workgiver

### DIFF
--- a/Source/PickUpAndHaul/JobDriver_UnloadYourHauledInventory.cs
+++ b/Source/PickUpAndHaul/JobDriver_UnloadYourHauledInventory.cs
@@ -301,13 +301,18 @@ public class JobDriver_UnloadYourHauledInventory : JobDriver
 
 
 
+        private static readonly List<Thing> _tmpThingList = new();
+
         private static ThingCount FirstUnloadableThing(Pawn pawn, HashSet<Thing> carriedThings)
         {
-			PerformanceProfiler.StartTimer("FirstUnloadableThing");
+                        PerformanceProfiler.StartTimer("FirstUnloadableThing");
                 var innerPawnContainer = pawn.inventory.innerContainer;
                 Thing best = null;
 
-                foreach (var thing in carriedThings)
+                _tmpThingList.Clear();
+                _tmpThingList.AddRange(carriedThings);
+
+                foreach (var thing in _tmpThingList)
                 {
                         // Handle stacks that changed IDs after being picked up
                         if (!innerPawnContainer.Contains(thing))


### PR DESCRIPTION
## Summary
- cache PotentialWorkThingsGlobal results per pawn per tick
- reuse static lists for haulables and storage filtered items
- fix FirstUnloadableThing to avoid modifying HashSet while iterating
- clear temporary lists on early returns

## Testing
- `dotnet build` for `Source/IHoldMultipleThings`
- `dotnet build` for `Source/PickUpAndHaul`

------
https://chatgpt.com/codex/tasks/task_e_6872a9b3b0e883329eb14ab39bb87148