### PR TITLE
Fix capacity reservation bug after unloading

### DIFF
--- a/Source/PickUpAndHaul/StorageAllocationTracker.cs
+++ b/Source/PickUpAndHaul/StorageAllocationTracker.cs
@@ -212,6 +212,7 @@ namespace PickUpAndHaul
                     {
                         try
                         {
+                            tempThing.stackCount = itemDef.stackLimit;
                             var capacity = thingOwner.GetCountCanAccept(tempThing);
                             return capacity;
                         }
@@ -238,6 +239,7 @@ namespace PickUpAndHaul
                 {
                     try
                     {
+                        tempThing.stackCount = itemDef.stackLimit;
                         var capacity = WorkGiver_HaulToInventory.CapacityAt(tempThing, location.Cell, map);
                         return capacity;
                     }
@@ -288,7 +290,9 @@ namespace PickUpAndHaul
                     var stuff = itemDef.defaultStuff ?? GenStuff.DefaultStuffFor(itemDef);
                     if (stuff != null)
                     {
-                        return ThingMaker.MakeThing(itemDef, stuff);
+                        var thing = ThingMaker.MakeThing(itemDef, stuff);
+                        thing.stackCount = itemDef.stackLimit;
+                        return thing;
                     }
                     else
                     {
@@ -298,7 +302,9 @@ namespace PickUpAndHaul
                 }
                 else
                 {
-                    return ThingMaker.MakeThing(itemDef);
+                    var thing = ThingMaker.MakeThing(itemDef);
+                    thing.stackCount = itemDef.stackLimit;
+                    return thing;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- prevent under-estimated storage capacity
- create temporary things with full stack count when probing storage capacity

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6872cfa7f7a48332b3fde70d648e6978