### PR TITLE
Fix hauling capacity sync bug

### DIFF
--- a/Source/PickUpAndHaul/StorageAllocationTracker.cs
+++ b/Source/PickUpAndHaul/StorageAllocationTracker.cs
@@ -77,16 +77,25 @@ namespace PickUpAndHaul
             lock (_lockObject)
             {
                 // Get actual storage capacity
-                int actualCapacity = GetActualCapacity(location, itemDef, map);
-                
-                // Subtract pending allocations
-                int pendingAmount = GetPendingAllocation(location, itemDef);
-                
-                int availableCapacity = actualCapacity - pendingAmount;
-                
-                Log.Message($"[StorageAllocationTracker] Location {location}: actual={actualCapacity}, pending={pendingAmount}, available={availableCapacity}, requested={requestedAmount}");
-                
+                int availableCapacity = GetAvailableCapacity(location, itemDef, map);
+
+                Log.Message($"[StorageAllocationTracker] Location {location}: available={availableCapacity}, requested={requestedAmount}");
+
                 return availableCapacity >= requestedAmount;
+            }
+        }
+
+        /// <summary>
+        /// Get the available capacity at a location after considering pending reservations
+        /// </summary>
+        public static int GetAvailableCapacity(StorageLocation location, ThingDef itemDef, Map map)
+        {
+            lock (_lockObject)
+            {
+                int actualCapacity = GetActualCapacity(location, itemDef, map);
+                int pendingAmount = GetPendingAllocation(location, itemDef);
+                int availableCapacity = Mathf.Max(0, actualCapacity - pendingAmount);
+                return availableCapacity;
             }
         }
 

--- a/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
@@ -169,19 +169,10 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 				{
 					// Check if storage has any meaningful capacity for this item
 					// This prevents the HasJobOnThing/JobOnThing synchronization issue
-					var storageCapacity = 0;
-					if (haulDestination is ISlotGroupParent)
-					{
-						storageCapacity = CapacityAt(thing, foundCell, pawn.Map);
-					}
-					else if (haulDestination is Thing destinationThing)
-					{
-						var thingOwner = destinationThing.TryGetInnerInteractableThingOwner();
-						if (thingOwner != null)
-						{
-							storageCapacity = thingOwner.GetCountCanAccept(thing);
-						}
-					}
+                                        var storageLocation = haulDestination is ISlotGroupParent
+                                                ? new StorageAllocationTracker.StorageLocation(foundCell)
+                                                : new StorageAllocationTracker.StorageLocation((Thing)haulDestination);
+                                        var storageCapacity = StorageAllocationTracker.GetAvailableCapacity(storageLocation, thing.def, pawn.Map);
 					
 					if (storageCapacity <= 0)
 					{
@@ -352,10 +343,12 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 			return null;
 		}
 
-		//credit to Dingo
-		var capacityStoreCell
-			= storeTarget.container is null ? CapacityAt(thing, storeTarget.cell, map)
-			: nonSlotGroupThingOwner.GetCountCanAccept(thing);
+                //credit to Dingo
+                var storageLocationInit = storeTarget.container != null
+                        ? new StorageAllocationTracker.StorageLocation(storeTarget.container)
+                        : new StorageAllocationTracker.StorageLocation(storeTarget.cell);
+
+                var capacityStoreCell = StorageAllocationTracker.GetAvailableCapacity(storageLocationInit, thing.def, map);
 
 		if (capacityStoreCell == 0)
 		{


### PR DESCRIPTION
## Summary
- add `GetAvailableCapacity` to `StorageAllocationTracker`
- use new method when checking storage in `HasJobOnThing`
- use new method when creating hauling jobs to avoid stale capacity info

## Testing
- `dotnet build Source/IHoldMultipleThings/IHoldMultipleThings.csproj -c Release`
- `dotnet build Source/PickUpAndHaul/PickUpAndHaul16.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6872cfa7f7a48332b3fde70d648e6978