### PR TITLE
Fix capacity calculation for storage allocation

### DIFF
--- a/Source/PickUpAndHaul/StorageAllocationTracker.cs
+++ b/Source/PickUpAndHaul/StorageAllocationTracker.cs
@@ -288,7 +288,10 @@ namespace PickUpAndHaul
                     var stuff = itemDef.defaultStuff ?? GenStuff.DefaultStuffFor(itemDef);
                     if (stuff != null)
                     {
-                        return ThingMaker.MakeThing(itemDef, stuff);
+                        var temp = ThingMaker.MakeThing(itemDef, stuff);
+                        // Ensure stackCount reflects maximum stack size for accurate capacity checks
+                        temp.stackCount = itemDef.stackLimit;
+                        return temp;
                     }
                     else
                     {
@@ -298,7 +301,10 @@ namespace PickUpAndHaul
                 }
                 else
                 {
-                    return ThingMaker.MakeThing(itemDef);
+                    var temp = ThingMaker.MakeThing(itemDef);
+                    // Ensure stackCount reflects maximum stack size for accurate capacity checks
+                    temp.stackCount = itemDef.stackLimit;
+                    return temp;
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- ensure temporary things used for capacity checks reflect the item's full stack size

## Testing
- `dotnet build` for `Source/IHoldMultipleThings`
- `dotnet build` for `Source/PickUpAndHaul`


------
https://chatgpt.com/codex/tasks/task_e_6872cfa7f7a48332b3fde70d648e6978