### PR TITLE
Fix target queue removal logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,4 +374,4 @@ Thumbs.db
 *.log
 *.log.*
 1.5/
- 
+ ReferenceMods/

--- a/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
+++ b/Source/PickUpAndHaul/WorkGiver_HaulToInventory.cs
@@ -630,25 +630,31 @@ public class WorkGiver_HaulToInventory : WorkGiver_HaulGeneral
 				break;
 			}
 
-			if (carryCapacity <= 0)
-			{
-				var originalCount = job.countQueue.Pop();
-				var adjustedCount = originalCount + carryCapacity;
-				
-				if (adjustedCount <= 0)
-				{
-					// Remove the item entirely if the adjusted count is 0 or negative
-					job.targetQueueA.RemoveAt(job.targetQueueA.Count - 1);
-					job.targetQueueB.RemoveAt(job.targetQueueB.Count - 1);
-					Log.Message($"[PickUpAndHaul] DEBUG: Removed last item from job - adjusted count would be {adjustedCount} (original: {originalCount}, carryCapacity: {carryCapacity})");
-				}
-				else
-				{
-					job.countQueue.Add(adjustedCount);
-					Log.Message($"[PickUpAndHaul] DEBUG: Adjusted count from {originalCount} to {adjustedCount} (carryCapacity: {carryCapacity})");
-				}
-				break;
-			}
+                        if (carryCapacity <= 0)
+                        {
+                                var originalCount = job.countQueue.Pop();
+                                var adjustedCount = originalCount + carryCapacity;
+
+                                if (adjustedCount <= 0)
+                                {
+                                        // Remove the item entirely if the adjusted count is 0 or negative
+                                        job.targetQueueA.RemoveAt(job.targetQueueA.Count - 1);
+
+                                        // Only remove from targetQueueB when it was created for this item
+                                        if (job.targetQueueB.Count == job.targetQueueA.Count + 1)
+                                        {
+                                                job.targetQueueB.RemoveAt(job.targetQueueB.Count - 1);
+                                        }
+
+                                        Log.Message($"[PickUpAndHaul] DEBUG: Removed last item from job - adjusted count would be {adjustedCount} (original: {originalCount}, carryCapacity: {carryCapacity})");
+                                }
+                                else
+                                {
+                                        job.countQueue.Add(adjustedCount);
+                                        Log.Message($"[PickUpAndHaul] DEBUG: Adjusted count from {originalCount} to {adjustedCount} (carryCapacity: {carryCapacity})");
+                                }
+                                break;
+                        }
 		}
 
 		Log.Message($"[PickUpAndHaul] DEBUG: Final job state before return:");


### PR DESCRIPTION
## Summary
- avoid removing targetQueueB entry if it wasn't added for the last item
- ignore ReferenceMods directory in git

## Testing
- `dotnet build` in `Source/IHoldMultipleThings`
- `dotnet build` in `Source/PickUpAndHaul`

------
https://chatgpt.com/codex/tasks/task_e_68746bc05d3c8332bacd9b70c12d7e36